### PR TITLE
Allow content and loaded scripts to be customisable

### DIFF
--- a/consent-banner.es5.js
+++ b/consent-banner.es5.js
@@ -1,75 +1,111 @@
-'use strict';
-
-window.BarnardosConsent = function(options) {
+"use strict";
+window.BarnardosConsent = function (options) {
   if (!options.gtmCode) {
+    return;
+  }
+  var static_defaults = {
+    privacyURL: "https://www.barnardos.org.uk/privacy-notice",
+    cookieURL: "https://www.barnardos.org.uk/cookie-notice",
+    bannerHeading: "Cookie tracking preference",
+    buttonClass: "_barnardos-consent-banner__button",
+    buttonElement: "button",
+    closeButtonContent: "&#x2715;",
+    closeButtonClass: "_barnardos-cookie-close",
+    styleContent:
+      "._barnardos-cookie-overlay{z-index:3;position:fixed;top:0;left:0;width:100%;height:100%;background-color: rgba(0,0,0,0.7);}._barnardos-consent-banner {background-color:#fff;padding:0.5rem 1rem 1rem;position:fixed;top:10%;right:5%;bottom:10%;left:5%;z-index:4;overflow-y:scroll}@media screen and (min-width:360px) and (min-height:600px){._barnardos-consent-banner {top:50%;left:50%;bottom:30%;width:90%;max-width:36rem;transform:translate(-50%,-50%);bottom:auto}}._barnardos-consent-banner:focus{outline:none}._barnardos-consent-banner h2 {margin-right:2rem}._barnardos-consent-banner p {display:inline-block;margin:0.5rem 0 1.5rem;vertical-align:middle}._barnardos-consent-banner div{display:inline-block;white-space:nowrap}._barnardos-consent-banner button {appearance: none; background-color: #558200; border: 1px solid #558200; border-radius: 0; color: #fff; display: inline-block; font-size: 1.125rem; font-weight: 800; letter-spacing: 0; line-height: 1.5rem; padding: 0.5rem 2rem; text-align: center; user-select: none; vertical-align: middle; white-space: nowrap; margin:0 1em 0 0;}._barnardos-consent-banner button:hover, ._barnardos-consent-banner button:focus { background-color: #192700; border-color: #192700; }._barnardos-consent-banner a {text-decoration:underline}._barnardos-consent-banner ._barnardos-cookie-close{position:absolute;right:0;top:0;margin:0;line-height:1;padding:0.5rem}",
+  };
+  Object.keys(static_defaults).forEach((key) => {
+    options[key] = options[key] || static_defaults[key];
+  });
+  //dynamic defaults
+  options.bannerContent =
+    options.bannerContent ||
+    `We use cookies to improve your experience on our site, show you personalised marketing and information and to help us understand how you use the site. By pressing accept, you agree to us storing those cookies on your device. By pressing reject, you refuse the use of all cookies except those that are essential to the running of our website. See our <a href="${options.privacyURL}">privacy policy</a> and <a href="${options.cookieURL}">cookie notice</a> for more details.`;
+  barnardosCustomConsent(options);
+};
+
+function barnardosCustomConsent(options) {
+  var missingMandatoryOptions = "missing mandatory options";
+  "bannerHeading bannerContent buttonClass buttonElement closeButtonContent closeButtonClass styleContent"
+    .split(" ")
+    .forEach(
+      (option) =>
+        (missingMandatoryOptions += options[option] ? "" : `, ${option}`),
+    );
+
+  missingMandatoryOptions +=
+    options.useExternalStylesheet || options.styleContent
+      ? ""
+      : ",styleContent";
+
+  if (missingMandatoryOptions != "missing mandatory options") {
+    console.warn(missingMandatoryOptions);
     return;
   }
 
   var gtmCode = options.gtmCode;
 
-  if(options.privacyURL) {
-    var privacyURL = options.privacyURL;
-  } else {
-    var privacyURL = 'https://www.barnardos.org.uk/privacy-notice';
-  } 
-
-  if(options.cookieURL) {
-    var cookieURL = options.cookieURL;
-  } else {
-    var cookieURL = 'https://www.barnardos.org.uk/cookie-notice';
-  }
-
-  var getCookieValue = function(name) {
+  var getCookieValue = function (name) {
     var result = document.cookie.match(
-      '(^|[^;]+)\\s*' + name + '\\s*=\\s*([^;]+)'
+      "(^|[^;]+)\\s*" + name + "\\s*=\\s*([^;]+)",
     );
-    return result ? result.pop() : '';
+    return result ? result.pop() : "";
   };
 
   // Build a button
-  var buildButton = function(text) {
-    var button = document.createElement('button');
-    button.type = 'button';
+  var buildButton = function (text) {
+    var button = document.createElement(options.buttonElement);
+    switch (options.buttonElement) {
+      case "button":
+        button.type = "button";
+      case "a":
+        button.setAttribute("href", "#");
+    }
     button.id = text.toLowerCase();
     button.textContent = text;
-    button.className = '_barnardos-consent-banner__button';
+    button.className = options.buttonClass;
     return button;
   };
 
   // Create the two buttons and a placeholder for the banner
-  var consentBanner = document.createElement('div');
-  var rejectButton = buildButton('Reject');
-  var acceptButton = buildButton('Accept');
+  var consentBanner = document.createElement("div");
+  var rejectButton = buildButton("Reject");
+  var acceptButton = buildButton("Accept");
   var cookieOverlay = document.createElement("div");
-  var closeButton = document.createElement("button");
+  var closeButton = document.createElement(options.buttonElement);
+  if (options.buttonElement == "a") {
+    closeButton.setAttribute("href", "#");
+  }
 
   // Build the banner
-  var buildBanner = function() {    
+  var buildBanner = function () {
     cookieOverlay.className = "_barnardos-cookie-overlay";
     cookieOverlay.id = "overlay";
-    consentBanner.className = '_barnardos-consent-banner';    
+    consentBanner.className = "_barnardos-consent-banner";
     consentBanner.setAttribute("role", "dialog");
     consentBanner.setAttribute("aria-modal", "true");
     consentBanner.setAttribute("aria-labelledby", "dialog-title");
     consentBanner.setAttribute("aria-describedby", "dialog-description");
-    consentBanner.setAttribute("tabindex", "-1");    
+    consentBanner.setAttribute("tabindex", "-1");
     closeButton.id = "close";
-    closeButton.className = "_barnardos-cookie-close";
+    closeButton.className = options.closeButtonClass;
     closeButton.setAttribute("aria-label", "Close cookie tracking preference");
-    closeButton.innerHTML = "&#x2715;";
+    closeButton.innerHTML = options.closeButtonContent;
     var heading = document.createElement("h2");
-    heading.textContent = "Cookie tracking preference";
+    heading.textContent = options.bannerHeading;
     heading.className = "_barnardos-cookie-heading";
     heading.id = "dialog-title";
-    var text = document.createElement('p');
+    var text = document.createElement("p");
     text.id = "dialog-description";
-    text.innerHTML = 'We use cookies to improve your experience on our site, show you personalised marketing and information and to help us understand how you use the site. By pressing accept, you agree to us storing those cookies on your device. By pressing reject, you refuse the use of all cookies except those that are essential to the running of our website. See our <a href="'+ privacyURL +'">privacy policy</a> and <a href="'+ cookieURL +'">cookie notice</a> for more details.';
-    var style = document.createElement('style');
-    style.textContent = "._barnardos-cookie-overlay{z-index:3;position:fixed;top:0;left:0;width:100%;height:100%;background-color: rgba(0,0,0,0.7);}._barnardos-consent-banner {background-color:#fff;padding:0.5rem 1rem 1rem;position:fixed;top:10%;right:5%;bottom:10%;left:5%;z-index:4;overflow-y:scroll}@media screen and (min-width:360px) and (min-height:600px){._barnardos-consent-banner {top:50%;left:50%;bottom:30%;width:90%;max-width:36rem;transform:translate(-50%,-50%);bottom:auto}}._barnardos-consent-banner:focus{outline:none}._barnardos-consent-banner h2 {margin-right:2rem}._barnardos-consent-banner p {display:inline-block;margin:0.5rem 0 1.5rem;vertical-align:middle}._barnardos-consent-banner div{display:inline-block;white-space:nowrap}._barnardos-consent-banner button {appearance: none; background-color: #558200; border: 1px solid #558200; border-radius: 0; color: #fff; display: inline-block; font-size: 1.125rem; font-weight: 800; letter-spacing: 0; line-height: 1.5rem; padding: 0.5rem 2rem; text-align: center; user-select: none; vertical-align: middle; white-space: nowrap; margin:0 1em 0 0;}._barnardos-consent-banner button:hover, ._barnardos-consent-banner button:focus { background-color: #192700; border-color: #192700; }._barnardos-consent-banner a {text-decoration:underline}._barnardos-consent-banner ._barnardos-cookie-close{position:absolute;right:0;top:0;margin:0;line-height:1;padding:0.5rem}";
-    consentBanner.appendChild(style);
+    text.innerHTML = options.bannerContent;
+    if (!options.useExternalStylesheet) {
+      const style = document.createElement("style");
+      style.textContent = options.styleContent;
+      consentBanner.appendChild(style);
+    }
     consentBanner.appendChild(heading);
     consentBanner.appendChild(text);
-    var buttonWrap = document.createElement('div');
+    var buttonWrap = document.createElement("div");
     buttonWrap.appendChild(rejectButton);
     buttonWrap.appendChild(acceptButton);
     consentBanner.appendChild(buttonWrap);
@@ -88,51 +124,65 @@ window.BarnardosConsent = function(options) {
   };
 
   // Close consent banner
-  var closeConsentBanner = function() {
+  var closeConsentBanner = function () {
     consentBanner.parentNode.removeChild(consentBanner);
     cookieOverlay.parentNode.removeChild(cookieOverlay);
     var expires = new Date();
     expires.setDate(expires.getDate() + 365);
     document.cookie =
-      'consentBanner=closed; expires=' +
+      "consentBanner=closed; expires=" +
       expires +
-      ';domain=.barnardos.org.uk; path=/; SameSite=Strict';
+      ";domain=.barnardos.org.uk; path=/; SameSite=Strict";
   };
 
   // Load the scripts and trackers
-  // Using the minified code GTM gives us
-  var loadScripts = function(w, d, s, l, i) {
-    w[l] = w[l] || [];
-    w[l].push({
-      'gtm.start': new Date().getTime(),
-      event: 'gtm.js'
+  options.gtmCode &&
+    (options.scripts = options.scripts || []).push({
+      // GTM script using the minified code GTM gives us
+      name: "GTM",
+      script: function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({
+          "gtm.start": new Date().getTime(),
+          event: "gtm.js",
+        });
+        var f = d.getElementsByTagName(s)[0];
+        var j = d.createElement(s);
+        var dl = l != "dataLayer" ? "&l=" + l : "";
+        j.async = true;
+        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+        f.parentNode.insertBefore(j, f);
+      },
+      args: [window, document, "script", "dataLayer", options.gtmCode],
     });
-    var f = d.getElementsByTagName(s)[0];
-    var j = d.createElement(s);
-    var dl = l != 'dataLayer' ? '&l=' + l : '';
-    j.async = true;
-    j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
-    f.parentNode.insertBefore(j, f);
+  if (!options.scripts) {
+    return;
+  }
+
+  var loadScripts = function () {
+    options.scripts.forEach(function (script) {
+      script.script(...script.args);
+    });
     // Add acceptance to cookie so we can load the
     // Trackers and scripts with subsequent page views
     var expires = new Date();
     expires.setDate(expires.getDate() + 365);
     document.cookie =
-      'consentAction=accept; expires=' +
+      "consentAction=accept; expires=" +
       expires +
-      ';domain=.barnardos.org.uk; path=/; SameSite=Strict';
+      ";domain=.barnardos.org.uk; path=/; SameSite=Strict";
   };
 
   // Create a YYYY-MM date format
-  var formatDate = function(timestamp) {
+  var formatDate = function (timestamp) {
     var date = new Date(timestamp * 1000);
     var year = date.getFullYear();
-    var month = ('0' + (date.getMonth() + 1)).slice(-2);
-    return year + '-' + month;
+    var month = ("0" + (date.getMonth() + 1)).slice(-2);
+    return year + "-" + month;
   };
 
   // Send a POST request to a click tracker
-  var sendClickAction = function(closer) {
+  var sendClickAction = function (closer) {
     // Make a UNIX timestamp
     var time = Math.round(new Date().getTime() / 1000);
     var date = formatDate(time);
@@ -141,44 +191,16 @@ window.BarnardosConsent = function(options) {
       time: time,
       date: date,
       value: closer,
-      subdomain: location.hostname.split('.')[0]
+      subdomain: location.hostname.split(".")[0],
     };
     // Send the object
     if (window.XMLHttpRequest) {
       var request = new XMLHttpRequest();
       var url =
-        'https://barnardos-cors-anywhere.herokuapp.com/https://cookie-banner-click-counter.herokuapp.com/ajax-accept.php';
-      request.open('POST', url, true);
-      request.setRequestHeader('Content-type', 'application/json');
-      request.onreadystatechange = function() {
-        if (request.readyState === XMLHttpRequest.DONE) {
-          if (request.status !== 200) {
-            console.error('Error sending data to click action tracker');
-          }
-        }
-      };
-      request.send(JSON.stringify(obj));
-    }
-  };
-
-  // Send a banner load event to the counter
-  var sendLoad = function() {
-    // Make a UNIX timestamp
-    var time = Math.round(new Date().getTime() / 1000);
-    var date = formatDate(time);
-    // Build an object to send as JSON
-    var obj = {
-      time: time,
-      date: date
-    };
-    // Send the object
-    if (window.XMLHttpRequest) {
-      var request = new XMLHttpRequest();
-      var url =
-        "https://barnardos-cors-anywhere.herokuapp.com/https://cookie-banner-click-counter.herokuapp.com/ajax-load-accept.php";
+        "https://barnardos-cors-anywhere.herokuapp.com/https://cookie-banner-click-counter.herokuapp.com/ajax-accept.php";
       request.open("POST", url, true);
       request.setRequestHeader("Content-type", "application/json");
-      request.onreadystatechange = function() {
+      request.onreadystatechange = function () {
         if (request.readyState === XMLHttpRequest.DONE) {
           if (request.status !== 200) {
             console.error("Error sending data to click action tracker");
@@ -189,21 +211,49 @@ window.BarnardosConsent = function(options) {
     }
   };
 
-  var handleForwardTab = function(e) {
+  // Send a banner load event to the counter
+  var sendLoad = function () {
+    // Make a UNIX timestamp
+    var time = Math.round(new Date().getTime() / 1000);
+    var date = formatDate(time);
+    // Build an object to send as JSON
+    var obj = {
+      time: time,
+      date: date,
+    };
+    // Send the object
+    if (window.XMLHttpRequest) {
+      var request = new XMLHttpRequest();
+      var url =
+        "https://barnardos-cors-anywhere.herokuapp.com/https://cookie-banner-click-counter.herokuapp.com/ajax-load-accept.php";
+      request.open("POST", url, true);
+      request.setRequestHeader("Content-type", "application/json");
+      request.onreadystatechange = function () {
+        if (request.readyState === XMLHttpRequest.DONE) {
+          if (request.status !== 200) {
+            console.error("Error sending data to click action tracker");
+          }
+        }
+      };
+      request.send(JSON.stringify(obj));
+    }
+  };
+
+  var handleForwardTab = function (e) {
     if (document.activeElement === lastFocusableElement) {
       e.preventDefault();
       firstFocusableElement.focus();
     }
   };
 
-  var handleBackwardTab = function(e) {
+  var handleBackwardTab = function (e) {
     if (document.activeElement === firstFocusableElement) {
       e.preventDefault();
       lastFocusableElement.focus();
     }
   };
 
-  if (getCookieValue('consentBanner') !== 'closed') {
+  if (getCookieValue("consentBanner") !== "closed") {
     // Check if the banner has been loaded and if not send a session load to the counter
     if (sessionStorage.consentBannerSessionLoad !== "loaded") {
       sendLoad();
@@ -214,42 +264,43 @@ window.BarnardosConsent = function(options) {
 
   // If cookies are previously accepted run the function
   // To load the trackers and scripts
-  if (getCookieValue('consentAction') === 'accept') {
-    loadScripts(window, document, 'script', 'dataLayer', gtmCode);
+  if (getCookieValue("consentAction") === "accept") {
+    loadScripts();
   }
 
   // Listeners
   if (rejectButton) {
-    rejectButton.addEventListener('click', function(e) {
+    rejectButton.addEventListener("click", function (e) {
       closeConsentBanner();
       sendClickAction(e.target.id);
     });
   }
 
   if (acceptButton) {
-    acceptButton.addEventListener('click', function(e) {
+    acceptButton.addEventListener("click", function (e) {
       closeConsentBanner();
-      loadScripts(window, document, 'script', 'dataLayer', gtmCode);
+      loadScripts();
       sendClickAction(e.target.id);
+      options.onAccept && options.onAccept();
     });
   }
 
   if (cookieOverlay) {
-    cookieOverlay.addEventListener("click", function(e) {
+    cookieOverlay.addEventListener("click", function (e) {
       closeConsentBanner();
       sendClickAction(e.target.id);
     });
   }
 
   if (closeButton) {
-    closeButton.addEventListener("click", function(e) {
+    closeButton.addEventListener("click", function (e) {
       closeConsentBanner();
       sendClickAction(e.target.id);
     });
   }
 
   if (consentBanner) {
-    consentBanner.addEventListener("keydown", function(e) {
+    consentBanner.addEventListener("keydown", function (e) {
       switch (e.key) {
         case "Tab":
           if (e.shiftKey) {
@@ -267,4 +318,4 @@ window.BarnardosConsent = function(options) {
       }
     });
   }
-};
+}

--- a/consent-banner.node.js
+++ b/consent-banner.node.js
@@ -1,24 +1,12 @@
-module.exports = () => {
+module.exports = (options) => {
 
   const gtmCode = process.env.GTM_CODE;
   if (!gtmCode) {
     return;
   }
 
-  let privacyURL; 
-  let cookieURL;
-
-  if(process.env.PRIVACY_URL) {
-    privacyURL = options.privacyURL;
-  } else {
-    privacyURL = 'https://www.barnardos.org.uk/privacy-notice';
-  } 
-
-  if(process.env.COOKIE_URL) {
-    cookieURL = options.cookieURL;
-  } else {
-    cookieURL = 'https://www.barnardos.org.uk/cookie-notice';
-  }
+  const privacyURL = options.privacyURL || process.env.PRIVACY_URL || 'https://www.barnardos.org.uk/privacy-notice';
+  const cookieURL = options.cookieURL || process.env.COOKIE_URL || 'https://www.barnardos.org.uk/cookie-notice';
 
   const getCookieValue = (name) => {
     const result = document.cookie.match(
@@ -59,15 +47,17 @@ module.exports = () => {
     closeButton.setAttribute("aria-label", "Close cookie tracking preference");
     closeButton.innerHTML = "&#x2715;";
     const heading = document.createElement("h2");
-    heading.textContent = "Cookie tracking preference";
+    heading.textContent = options.bannerHeading || "Cookie tracking preference";
     heading.className = "_barnardos-cookie-heading";
     heading.id = "dialog-title";
     const text = document.createElement('p');
     text.id = "dialog-description";
-    text.innerHTML = `We use cookies to improve your experience on our site, show you personalised marketing and information and to help us understand how you use the site. By pressing accept, you agree to us storing those cookies on your device. By pressing reject, you refuse the use of all cookies except those that are essential to the running of our website. See our <a href="${privacyURL}">privacy policy</a> and <a href="${cookieURL}">cookie notice</a> for more details.`;
-    const style = document.createElement('style');
-    style.textContent = "._barnardos-cookie-overlay{z-index:3;position:fixed;top:0;left:0;width:100%;height:100%;background-color: rgba(0,0,0,0.7);}._barnardos-consent-banner {background-color:#fff;padding:0.5rem 1rem 1rem;position:fixed;top:10%;right:5%;bottom:10%;left:5%;z-index:4;overflow-y:scroll}@media screen and (min-width:360px) and (min-height:600px){._barnardos-consent-banner {top:50%;left:50%;bottom:30%;width:90%;max-width:36rem;transform:translate(-50%,-50%);bottom:auto}}._barnardos-consent-banner:focus{outline:none}._barnardos-consent-banner h2 {margin-right:2rem}._barnardos-consent-banner p {display:inline-block;margin:0.5rem 0 1.5rem;vertical-align:middle}._barnardos-consent-banner div{display:inline-block;white-space:nowrap}._barnardos-consent-banner button {appearance: none; background-color: #558200; border: 1px solid #558200; border-radius: 0; color: #fff; display: inline-block; font-size: 1.125rem; font-weight: 800; letter-spacing: 0; line-height: 1.5rem; padding: 0.5rem 2rem; text-align: center; user-select: none; vertical-align: middle; white-space: nowrap; margin:0 1em 0 0;}._barnardos-consent-banner button:hover, ._barnardos-consent-banner button:focus { background-color: #192700; border-color: #192700; }._barnardos-consent-banner a {text-decoration:underline}._barnardos-consent-banner ._barnardos-cookie-close{position:absolute;right:0;top:0;margin:0;line-height:1;padding:0.5rem}";
-    consentBanner.appendChild(style);
+    text.innerHTML = options.bannerContent || `We use cookies to improve your experience on our site, show you personalised marketing and information and to help us understand how you use the site. By pressing accept, you agree to us storing those cookies on your device. By pressing reject, you refuse the use of all cookies except those that are essential to the running of our website. See our <a href="${privacyURL}">privacy policy</a> and <a href="${cookieURL}">cookie notice</a> for more details.`;
+    if (!options.useExternalStylesheet) {
+      const style = document.createElement('style');
+      style.textContent = "._barnardos-cookie-overlay{z-index:3;position:fixed;top:0;left:0;width:100%;height:100%;background-color: rgba(0,0,0,0.7);}._barnardos-consent-banner {background-color:#fff;padding:0.5rem 1rem 1rem;position:fixed;top:10%;right:5%;bottom:10%;left:5%;z-index:4;overflow-y:scroll}@media screen and (min-width:360px) and (min-height:600px){._barnardos-consent-banner {top:50%;left:50%;bottom:30%;width:90%;max-width:36rem;transform:translate(-50%,-50%);bottom:auto}}._barnardos-consent-banner:focus{outline:none}._barnardos-consent-banner h2 {margin-right:2rem}._barnardos-consent-banner p {display:inline-block;margin:0.5rem 0 1.5rem;vertical-align:middle}._barnardos-consent-banner div{display:inline-block;white-space:nowrap}._barnardos-consent-banner button {appearance: none; background-color: #558200; border: 1px solid #558200; border-radius: 0; color: #fff; display: inline-block; font-size: 1.125rem; font-weight: 800; letter-spacing: 0; line-height: 1.5rem; padding: 0.5rem 2rem; text-align: center; user-select: none; vertical-align: middle; white-space: nowrap; margin:0 1em 0 0;}._barnardos-consent-banner button:hover, ._barnardos-consent-banner button:focus { background-color: #192700; border-color: #192700; }._barnardos-consent-banner a {text-decoration:underline}._barnardos-consent-banner ._barnardos-cookie-close{position:absolute;right:0;top:0;margin:0;line-height:1;padding:0.5rem}";
+      consentBanner.appendChild(style);
+    }
     consentBanner.appendChild(heading);
     consentBanner.appendChild(text);
     const buttonWrap = document.createElement('div');

--- a/consent-banner.template.css
+++ b/consent-banner.template.css
@@ -1,0 +1,80 @@
+._barnardos-cookie-overlay {
+  z-index: 3;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.7);
+}
+._barnardos-consent-banner {
+  background-color: #fff;
+  padding: 0.5rem 1rem 1rem;
+  position: fixed;
+  top: 10%;
+  right: 5%;
+  bottom: 10%;
+  left: 5%;
+  z-index: 4;
+  overflow-y: scroll;
+}
+@media screen and (min-width: 360px) and (min-height: 600px) {
+  ._barnardos-consent-banner {
+    top: 50%;
+    left: 50%;
+    bottom: 30%;
+    width: 90%;
+    max-width: 36rem;
+    transform: translate(-50%, -50%);
+    bottom: auto;
+  }
+}
+._barnardos-consent-banner:focus {
+  outline: none;
+}
+._barnardos-consent-banner h2 {
+  margin-right: 2rem;
+}
+._barnardos-consent-banner p {
+  display: inline-block;
+  margin: 0.5rem 0 1.5rem;
+  vertical-align: middle;
+}
+._barnardos-consent-banner div {
+  display: inline-block;
+  white-space: nowrap;
+}
+._barnardos-consent-banner button {
+  appearance: none;
+  background-color: #558200;
+  border: 1px solid #558200;
+  border-radius: 0;
+  color: #fff;
+  display: inline-block;
+  font-size: 1.125rem;
+  font-weight: 800;
+  letter-spacing: 0;
+  line-height: 1.5rem;
+  padding: 0.5rem 2rem;
+  text-align: center;
+  user-select: none;
+  vertical-align: middle;
+  white-space: nowrap;
+  margin: 0 1em 0 0;
+}
+._barnardos-consent-banner button:hover,
+._barnardos-consent-banner button:focus {
+  background-color: #192700;
+  border-color: #192700;
+}
+._barnardos-consent-banner a {
+  text-decoration: underline;
+}
+._barnardos-consent-banner ._barnardos-cookie-close {
+  position: absolute;
+  right: 0;
+  top: 0;
+  margin: 0;
+  line-height: 1;
+  padding: 0.5rem;
+}


### PR DESCRIPTION
old Barnardos defaults are now accessed via a compatibility entry point

new entry point allows fully customisable:
- banner heading, 
- banner content text, 
- close button, 
- styling (or use of external stylesheet), 
- scripts to load if the cookie is accepted
- optional force reload once accept button pressed